### PR TITLE
feat: Add a plugin configuration to inject Processor instances

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,4 +124,4 @@ uploadArchives {
 
 
 group = 'fr.inria.gforge.spoon'
-version ='1.0'
+version ='1.1-SNAPSHOT'

--- a/src/main/groovy/fr/inria/gforge/spoon/SpoonAndroidPlugin.groovy
+++ b/src/main/groovy/fr/inria/gforge/spoon/SpoonAndroidPlugin.groovy
@@ -48,6 +48,7 @@ class SpoonAndroidPlugin implements Plugin<Project> {
                             preserveFormatting = project.spoon.preserveFormatting
                             noClasspath = project.spoon.noClasspath
                             processors = project.spoon.processors
+                            processorsInstance = project.spoon.processorsInstance
                             classpath = compileJavaTask.classpath + Utils.getAndroidSdk(project)
                             srcPath = variantSrcPath
                             compliance = project.spoon.compliance

--- a/src/main/groovy/fr/inria/gforge/spoon/SpoonAndroidTask.groovy
+++ b/src/main/groovy/fr/inria/gforge/spoon/SpoonAndroidTask.groovy
@@ -18,6 +18,7 @@ class SpoonAndroidTask extends DefaultTask {
     def boolean preserveFormatting
     def boolean noClasspath
     def String[] processors = []
+    Processor[] processorsInstance = []
     def FileCollection classpath
     def int compliance
 
@@ -53,6 +54,7 @@ class SpoonAndroidTask extends DefaultTask {
         Collection<Processor> processorsClasses = processors.collect {
             it -> this.class.classLoader.loadClass(it)?.newInstance()
         } as Collection<Processor>
+        processorsClasses.addAll(processorsInstance)
         compiler.process(processorsClasses);
         compiler.generateProcessedSourceFiles(OutputType.COMPILATION_UNITS);
     }

--- a/src/main/groovy/fr/inria/gforge/spoon/SpoonExtension.groovy
+++ b/src/main/groovy/fr/inria/gforge/spoon/SpoonExtension.groovy
@@ -1,6 +1,7 @@
 package fr.inria.gforge.spoon
 
 import org.gradle.api.file.FileCollection
+import spoon.processing.Processor
 
 class SpoonExtension {
     /** True to active the debug mode. */
@@ -20,6 +21,9 @@ class SpoonExtension {
 
     /** List of processors. */
     def String[] processors = []
+
+    /** List of already instantiated processors. */
+    Processor[] processorsInstance = []
 
     /** True to active the compilation of original sources. */
     def boolean compileOriginalSources


### PR DESCRIPTION
This enables to create processors with dependency injection
from Gradle plugins and configurations (e.g. give output file).