### PR TITLE
Changed ":" to File.separator for processors in SpoonTask

### DIFF
--- a/src/main/groovy/fr/inria/gforge/spoon/SpoonTask.groovy
+++ b/src/main/groovy/fr/inria/gforge/spoon/SpoonTask.groovy
@@ -40,7 +40,7 @@ class SpoonTask extends DefaultTask {
             addKey(params, '-x')
         }
         if (processors.size() != 0) {
-            addParam(params, '-p', processors.join(':'))
+            addParam(params, '-p', processors.join(File.separator))
         }
         if (!classpath.asPath.empty) {
             addParam(params, '--source-classpath', classpath.asPath)

--- a/src/main/groovy/fr/inria/gforge/spoon/SpoonTask.groovy
+++ b/src/main/groovy/fr/inria/gforge/spoon/SpoonTask.groovy
@@ -40,7 +40,7 @@ class SpoonTask extends DefaultTask {
             addKey(params, '-x')
         }
         if (processors.size() != 0) {
-            addParam(params, '-p', processors.join(File.separator))
+            addParam(params, '-p', processors.join(File.pathSeparator))
         }
         if (!classpath.asPath.empty) {
             addParam(params, '--source-classpath', classpath.asPath)


### PR DESCRIPTION
Fix for this exception when more than 1 String is placed within the processor

`Unable to load processor "com.annotationtest.processor.GraqhQlProcessor:com.annotationtest.processor.ClassProcessor" - Check your classpath.`

This is because the launcher.java class in spoon-core splits the processors by File.separator instead of colon.

```
if (getArguments().getString("processors") != null) {
			for (String processorName : getArguments().getString("processors").split(File.pathSeparator)) {
				addProcessor(processorName);
			}
		}
```

```
spoon {
    debug = true
    processors =["com.annotationtest.processor.GraqhQlProcessor","com.annotationtest.processor.ClassProcessor"]

    srcFolders = project.files('src/main/java/pojos')
    outFolder = new File("project/src/main/java/generated")
}
```


